### PR TITLE
quizzes/newページ入力制限と入力時エラーメッセージと注意事項

### DIFF
--- a/app/assets/stylesheets/home.css
+++ b/app/assets/stylesheets/home.css
@@ -9,8 +9,9 @@
   background-color: #f4f5d5;
   height: 110px;
   width: 100%; /* フッターを画面の幅いっぱいに */
-  position: fixed; /* 画面の下部に固定 */
-  bottom: 0; /* 下部に配置 */
+  /*position: fixed; 画面の下部に固定 　スクロール系*/
+  position: fixed;/* 常にページの下部に配置 */
+  bottom: 0;  /*下部に配置 */
   
 }
 

--- a/app/assets/stylesheets/quizzes.css
+++ b/app/assets/stylesheets/quizzes.css
@@ -9,13 +9,13 @@
   background-color: #f4f5d5;
   height: 110px;
   width: 100%; /* フッターを画面の幅いっぱいに */
-  position: fixed; /* 画面の下部に固定 */
-  bottom: 0; /* 下部に配置 */
+  /*position: fixed; 画面の下部に固定 　スクロール系*/
+  bottom: 0;  /*下部に配置 */
   
 }
 
 
-
+/*ーーーーここから新規投稿作成ページquizzes/indexのCSSになりますーーーーーーーー*/
 .quiz_options_container {
   display: flex;               /* 横並びにする */
   flex-wrap: wrap;             /* 3つで折り返す */
@@ -38,8 +38,12 @@
 
 
 
-/*ーーーーここから新規投稿作成ページquiznewのCSSになりますーーーーーーーー*/
+/*ーーーーここから新規投稿作成ページquizzes/newのCSSになりますーーーーーーーー*/
 
+.messages{
+  text-align: center; 
+  color: rgb(255, 115, 0);
+}
 .quiz_new {
   gap: 20px;                   /* 各要素の間にスペースを追加 */
   justify-content: space-between; /* 余白を均等に配置 */
@@ -52,7 +56,8 @@
   padding: 20px;               /* 内側の余白 */
   border-radius: 10px;         /* 角を丸める */
 }
-
+/**/
+/*-------題名---------*/
 .new_title input{
   background-color: #fdfdfd;   /* 背景色 */
   border: 2px solid #66b0f9;      /* 枠線 */
@@ -61,7 +66,14 @@
   text-align: center;    
 }
  
-
+.new_title small {
+  font-size: 12px; /* 文字を小さくする */
+  display: block;  /* 改行する */
+  margin-bottom: 10px; /* 入力フィールドとの間に余白を入れる */
+  margin-top: -7px;/*文字全体を上に上げてます*/
+  color: rgb(255, 0, 0);
+}
+/*-------問題集---------*/
 .new_problem textarea{
   background-color: #fdfdfd;   /* 背景色 */
   border: 2px solid #66b0f9;   /* 枠線 */
@@ -72,6 +84,15 @@
   overflow-wrap: break-word;   /* 単語の途中で折り返し */
 }
 
+.new_problem small{
+  font-size: 12px; /* 文字を小さくする */
+  display: block;  /* 改行する */
+  margin-bottom: 10px; /* 入力フィールドとの間に余白を入れる */
+  margin-top: -7px;/*文字全体を上に上げてます*/
+  color: rgb(255, 0, 0);
+}
+
+/*-------回答---------*/
 .new_request_1 input{
   background-color: #fdfdfd;   /* 背景色 */
   border: 2px solid #66b0f9;      /* 枠線 */
@@ -80,6 +101,16 @@
   text-align: center;  
 
 }
+
+.new_request_1 small{
+  font-size: 12px; /* 文字を小さくする */
+  display: block;  /* 改行する */
+  margin-bottom: 10px; /* 入力フィールドとの間に余白を入れる */
+  margin-top: -7px;/*文字全体を上に上げてます*/
+  color: rgb(255, 0, 0);
+}
+
+/*-------回答---------*/
 .new_request_2 input{
   background-color: #fdfdfd;   /* 背景色 */
   border: 2px solid #66b0f9;      /* 枠線 */
@@ -87,11 +118,28 @@
   height: 20px; /* 高さを200pxに設定 */
   text-align: center;  
 }
+
+.new_request_2 small{
+  font-size: 12px; /* 文字を小さくする */
+  display: block;  /* 改行する */
+  margin-bottom: 10px; /* 入力フィールドとの間に余白を入れる */
+  margin-top: -7px;/*文字全体を上に上げてます*/
+  color: rgb(255, 0, 0);
+}
+
+/*-------答え-----------*/
 .new_correct_answer input{
   background-color: #fdfdfd;   /* 背景色 */
   border: 2px solid #66b0f9;      /* 枠線 */
   width: 500px; /* 横幅を親要素いっぱいに */
   height: 20px; /* 高さを200pxに設定 */
   text-align: center;  
+}
 
+.new_correct_answer small{
+  font-size: 12px; /* 文字を小さくする */
+  display: block;  /* 改行する */
+  margin-bottom: 10px; /* 入力フィールドとの間に余白を入れる */
+  margin-top: -7px;/*文字全体を上に上げてます*/
+  color: rgb(255, 0, 0);
 }

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -18,9 +18,11 @@ class QuizzesController < ApplicationController
     )
     if 
       @quiz.save
-      redirect_to("/quizzes/new")
+      redirect_to("/quizzes/index")
+
     else
-      redirect_to("/")
+      redirect_to("/quizzes/new")
+      flash[:notice] = "入力に誤りがあるみたいです"
       #render :new
     end
   

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,4 +1,6 @@
 class Answer < ApplicationRecord
   belongs_to :quiz
   #belongs_to :user, optional: true  # user_id が nil でも許容される
+
+  validates :user_answer, {presence: true, length:{maximum: 50}}
 end

--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -3,10 +3,10 @@ class Quiz < ApplicationRecord
   accepts_nested_attributes_for :answer
 
   belongs_to :user
-  validates :question, presence: true
-  validates :answer_1, presence: true
-  validates :answer_2, presence: true
-  validates :title, presence: true
+  validates :question, {presence: true, length:{maximum: 250}}
+  validates :answer_1, {presence: true, length:{maximum: 50}}
+  validates :answer_2, {presence: true, length:{maximum: 50}}
+  validates :title, {presence: true, length:{maximum: 50}}
   #validates :user_answer, presence: true quizテーブルのカラムではないのでエラーが起きます
   
 end

--- a/app/views/quizzes/new.html.erb
+++ b/app/views/quizzes/new.html.erb
@@ -1,46 +1,51 @@
 <body>
   <div class="new_main">
     <div class="h1_title"><h1>Quizを投稿しよう!</h1></div>
+
+
+  
     <%= form_tag("/quizzes/create") do %>
+      <% if flash[:notice] %>
+        <div class="messages">
+           <%= flash[:notice] %>
+        </div>
+      <%end%>
+
       <div class="quiz_new">
         <div class="new_title">
           <p>題名</p>
+          <small>50文字以内で入力をお願いします</small>
           <input name="title" type="text">
         </div>
 
         <div class="new_problem">
           <p>問題集</p>
+          <small>250文字以内で入力をお願いします</small>
           <textarea name="question"></textarea>
         </div>
 
         <div class="new_request_1">
           <p>回答</p>
+          <small>50文字以内で入力をお願いします</small>
           <input name="answer_1" type="text">
         </div>
 
         <div class="new_request_2">
           <p>回答</p>
+          <small>50文字以内で入力をお願いします</small>
           <input name="answer_2" type="text">
         </div>
 
         <div class="new_correct_answer">
           <p>！正解！</p>
+          <small>50文字以内で入力をお願いします</small>
           <input name="user_answer" type="text">
         </div>
 
         <p><input type="submit" value="クイズを作成"></p>
-        <%=session[:user_id]%>
-      </div>
-      <% end %>
-      <p>20241014 quizのところでアンサーテーブルに制限をかけようとしてるのでエラーが怒っています</p>
-      <!--https://chatgpt.com/g/g-8sPlJ64Gn-tiyatutogpt/c/670c7e4f-a744-8010-bfd0-0f29fbf0ece6-->
-      <% if @quiz.errors.any? %>
-      <div id="error_explanation" class="alert alert-danger">
-        <p>入力内容に誤りがあります。すべての必須項目を入力してください。</p>
       </div>
     <% end %>
   </div>
   <div class="quiz_footer">
-      
   </div>
 </body>


### PR DESCRIPTION
概要
・新規投稿ページ/quizzes/newに、入力し投稿する際に文字の数の制限を行いました。
・入力に失敗した際にメッセージを出力、各入力欄にメッセージを追加

やった事
・quizテーブルのに制限を追加
・HTMLページに移りその制限を目視で確認できるよう文字を追加
・投稿の送信を行った際に誤りがあった場合は、メッセージを表示
・機能を追加した事によるスタイリング

課題
・エラーメッセージはかなり簡単に表示しましたので、
メッセージ用のモデルを作って配列として扱い、メッセージを表示させるか検討中

今後の活動
/quizzes/indexページについて
テーブルから全てのクイズの内容を表示していますが、このままだと新しいクイズを作成する度に
全てが表示対象となってしまって、１ページに対する表示の数が膨大になるので、１ページに対する表示したいクイズの制限をかけます。
それが終わり次第、矢印ボタンなどを作成し、２ページ、３ページと表示の切り替えの実装
