### PR TITLE
クイズ一覧、表示の制限と次と戻るボタン作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+
+gem "kaminari"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.7.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
     loofah (2.22.0)
@@ -311,6 +323,7 @@ DEPENDENCIES
   debug
   importmap-rails
   jbuilder
+  kaminari
   puma (>= 5.0)
   rails (~> 7.2.1)
   rubocop-rails-omakase

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -29,10 +29,23 @@ class QuizzesController < ApplicationController
   end
 
   def index
-    @quiz = Quiz.all
+    @quiz = Quiz.page(params[:page]).per(6)
     
-    #<%= quiz.answer.user_answer%>
+    #現在のページを取得、デフォルトは１
+    current_page = (params[:page] || 1).to_i
 
+    #1ページに表示するクイズの数
+    per_page = 6
+
+    #クイズをページに応じて取得する
+    @quiz = Quiz.order(created_at: :asc).offset((current_page -1)* per_page).limit(per_page)
+
+    # 次へボタン用のページ番号
+    @next_page = current_page + 1
+
+    # 戻るボタン用のページ番号ただし、1ページ目は戻れない）
+    @prev_page = current_page - 1 if current_page > 1
+    
   end
 
   def show

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -10,6 +10,17 @@
      <% end %>
    </div>
 
+   <!-- ページネーションのボタンを表示 -->
+    <div class="quiz_button">
+      <!-- 戻る -->
+      <% if @prev_page%>
+        <%= link_to('戻る', "/quizzes/index?page=#{@prev_page}")%>  
+      <%end%>
+
+      <!-- 次へボタン -->
+      <%= link_to('次へ', "/quizzes/index?page=#{@next_page}")%>
+    </div>
+
   </div>
   <div class="quiz_footer">
       


### PR DESCRIPTION
概要
投稿する度に、クイズが表示されていたのを、６つに制限をし
ボタン操作でクイズを表示する内容を変えるようにしました。

やった事
・quizzesControllerの変更
[def index]に制限とページをめくる処理を作成。
・quizzes.index.html
ページボタンを表示の処理を作成。

課題
この実装は一度チャットGPTを使用しているので、細かい部分で納得していない部分があるので
理解できるまでしっかり調べる。
quizzes.index.htmlのfooterの部分が常にクイズ表示に合わせて動くのでスタイリングで固定させる

次回やる事
各ページのfooterスタイリング
ユーザー一覧のスタイリング
ユーザー登録のスタイリング