### PR TITLE
ユーザーが問題を解く時にかかった時間を保存する際に小数点が出ていたので、整数に変更

### DIFF
--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -10,4 +10,3 @@
  <%= submit_tag '答えを送信' %>
 <% end %>
 
-<%= @quiz.total_time %>


### PR DESCRIPTION
概要
ユーザーが問題を解いた時にかかっている時間を保存する際に
小数点を含んでいたので、（HH:MM:SS）で保存できるように整数に変更

やった事
quizzesControllerの「def check_answer」の修正

課題
flash[:notice]使用し表示はできたものの
データベースには秒数で保存されているため、そのまま表示する際に（HH:MM:SS）ではなく
秒数のみで表示されます。ので、、、、データベースに保存されてある秒数を（HH:MM:SS）
で表示できるようHTMLファイルの修正

今後の活動
課題の通りuser index.html.erbファイルの修正