### PR TITLE
整理、一部削除ページあり

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,20 +33,16 @@ class ApplicationController < ActionController::Base
         quiz_result.save
 
         # ユーザーに正解したらスコア+1
-        @quiz.user.score = @quiz.user.score.to_i + 1
-        @quiz.user.save # スコアをデータベースに保存  
+        @user.score = @user.score.to_i + 1
+        @user.save # スコアをデータベースに保存  
         flash[:notice] = "正解 : #{time_in_hours}"
         
 
         # total_time が nil の場合は 0 に設定してから秒単位で加算
-        @quiz.user.total_time ||= 0.0
-        @quiz.user.total_time += elapsed_time.to_i # 秒単位で加算
-        @quiz.user.save
+        @user.total_time ||= 0.0
+        @user.total_time += elapsed_time.to_i # 秒単位で加算
+        @user.save
 
-        # 合計時間を "HH:MM:SS" 形式で表示
-        total_time_in_hours = seconds_to_time(@quiz.user.total_time)
-        flash[:notice] += " 総合時間: #{total_time_in_hours}"
-      
         redirect_to("/quizzes/new")
       else selected_answer != @quiz.answer.user_answer
         flash[:notice] = "不正解"

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -1,7 +1,5 @@
 class UserController < ApplicationController
-  def new
-  end
-
+  
   def index
     @users = User.order(score: :desc) 
     

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,6 @@
               <li><%= link_to("ユーザー一覧", "/user/index")%></li>
               <li><%= link_to("投稿","/quizzes/index")%></li>
             <%else%>
-              <li><%= link_to("新規ユーザ", "/user/new")%></li>
               <li><%= link_to("トップページ","/")%></li>
               <li><%= link_to("投稿","/quizzes/index")%></li>
             <%end%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   post "quizzes/:id/check_answer", to: "quizzes#check_answer"
 
 
-  get "user/new" => "user#new"
+ 
   get "user/index" => "user#index"
 
   get "/" => "home#top"


### PR DESCRIPTION
概要
・クイズに正解した時、回答にかかった全ての時間を表示していたのでそちらのコード削除
・今回は新規ユーザー作成ページはいらないと判断したので削除
・クイズに回答後、正解した合計時間と正解した数のスコアの合計が全て、ユーザーID１に保存
されていたので、ユーザーID2がログイン中で回答した場合、ユーザーID2に保存できるようにコード書き換え

なぜやったのか
不要なものを削除して、伝えやすくするため
最終動作確認をやっていて、不要と判断したものバグと判断したものを解決できるよう練習しました。