### PR TITLE
投稿ページの「次へ」ボタンの修正

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -43,6 +43,13 @@ class QuizzesController < ApplicationController
     # クイズをページに応じて取得する
     @quiz = Quiz.order(created_at: :asc).offset((current_page -1)* per_page).limit(per_page)
 
+    # クイズの総数
+    total_quizzes = Quiz.count
+
+    # 最後のページの判定
+    @is_last_page = (current_page * per_page) >= total_quizzes
+
+
     # 次へボタン用のページ番号
     @next_page = current_page + 1 
 

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -18,7 +18,9 @@
       <%end%>
 
       <!-- 次へボタン -->
-      <%= link_to('次へ', "/quizzes/index?page=#{@next_page}")%>
+      <% unless @is_last_page %>
+        <%= link_to('次へ', "/quizzes/index?page=#{@next_page}") %>
+      <% end %>
     </div>
 
   </div>


### PR DESCRIPTION
概要
投稿ページの「次へ」のボタンが永遠と押すことが可能だったため
ページの終わりに来たら非表示に変更をしました。

やった事
quizzes.controllerとindex.htmlファイルを修正し「次へ」の非表示の実行