### PR TITLE
モデルにバリデーションを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   has_many :quizzes, dependent: :destroy
-  
+
+  # メールアドレスのバリデーション
+  # 空白を許可しない、同じメールアドレスを許可しない　メールアドレスの形式をチェック
+  validates :email, presence: true, uniqueness: true,  format: { with: URI::MailTo::EMAIL_REGEXP }
+    
   # Quiz_result中間テーブルの紐付け
   has_many :quiz_results
   has_many :quizzes, through: :quiz_results


### PR DESCRIPTION
概要
ユーザーが持っている情報のメールアドレスに決まりがなかったので、このままだと適当な文字を入れる事が可能になってしまうため
メールアドレスを保存する際のバリデーションを追加しました。

やった事
メールアドレス、バリデーションの条件に空欄、他のユーザーと同じメールアドレスを保存できない、メールアドレスが正しい形式を追加しました。