### PR TITLE
非推奨のform_tagfから推奨のorm_withに変更

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -58,6 +58,7 @@ class QuizzesController < ApplicationController
   end
 
   def show
+    @quiz1 = Quiz.find_by(id: params[:id])
     @options = [@quiz.answer_1, @quiz.answer_2, @quiz.answer.user_answer].shuffle 
     @quiz.started_at = Time.current
     @quiz.save

--- a/app/views/quizzes/show.html.erb
+++ b/app/views/quizzes/show.html.erb
@@ -5,7 +5,21 @@
     
     <div class="quizzwa_show">
     <div class="quiz_question"><%= @quiz.question %></div>
-      <%= form_tag("/quizzes/#{@quiz.id}/check_answer", method: :post) do %>
+
+    <!-- fom_ウィズ  URLの開いたクイズIDのアンサー情報を送りたい--> 
+      <%= form_with(url: "/quizzes/#{@quiz.id}/check_answer", method: :post) do |form|%>
+        <% @options.each do |option| %> 
+          <div class="option"> 
+            <%= form.radio_button :selected_answer, option %>
+            <%= label_tag "selected_answer_#{option}", option %><br>
+          </div>
+        <% end %>
+        <div class="answer"><%= submit_tag '答えを送信' %></div>
+      <% end %>
+    </div>
+    <!-- fom_ウィズ -->
+
+    <!-- <%= form_tag("/quizzes/#{@quiz.id}/check_answer", method: :post) do %>
         <% @options.each do |option| %> 
           <div class="option">
             <%= radio_button_tag 'selected_answer', option %> 
@@ -14,8 +28,7 @@
         <% end %>
         <div class="answer"><%= submit_tag '答えを送信' %></div>
       <% end %>
-    </div>
-        <!-- fom_ウィズ -->
+    </div> -->
       
     
 


### PR DESCRIPTION
概要
非推奨のform_tagfから推奨のorm_withに変更しました

やったこと
form_tagをform_withに変更しました。
テスト環境では問題なく動いたのですが
herokuに乗せた時もし失敗していたらを考えて、コメントでform_tag残してます。